### PR TITLE
Missing comma in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ If you found this code useful, please consider citing the [OSS Vizier paper](htt
                Greg Kochanski and
                Daniel Golovin},
   title     = {Open Source Vizier: Distributed Infrastructure and API for Reliable and Flexible Blackbox Optimization},
-  booktitle = {Automated Machine Learning Conference, Systems Track (AutoML-Conf Systems)}
+  booktitle = {Automated Machine Learning Conference, Systems Track (AutoML-Conf Systems)},
   year      = {2022},
 }
 @inproceedings{google_vizier,


### PR DESCRIPTION
Vizier 2022 Paper Citation is missing a comma. Caused an error when I tried to cite in Latex.