### PR TITLE
pyglove/backend.py: remove invalid characters after function decorator

### DIFF
--- a/vizier/_src/pyglove/backend.py
+++ b/vizier/_src/pyglove/backend.py
@@ -419,7 +419,7 @@ class VizierBackend(pg.tuning.Backend):
           f'in study: {self._study.resource_name}.'
       ) from e
 
-  @functools.lru_cache(maxsize=None)d_property
+  @functools.lru_cache(maxsize=None)
   def _tuner_id(self) -> str:
     """Returns the tuner id of current ."""
     return self._tuner.get_tuner_id(self._algorithm)


### PR DESCRIPTION
Removes (what I think is) a bad edit introduced in https://github.com/google/vizier/commit/5aad0c02624006b7ef6c2d16615ce442a151a2bc#diff-f913e6960ace197c5499de1d7a0da89de6a4e5e567b18e11b963e3b38c094c2aR381:

```python
  @functools.lru_cache(maxsize=None)d_property
  def _tuner_id(self) -> str:
    """Returns the tuner id of current ."""
    return self._tuner.get_tuner_id(self._algorithm)
```

`d_property` isn't defined anywhere and causes the interpreter to throw a `SyntaxError`

```console
Traceback (most recent call last):
  File "/Users/connorbaker/Packages/ghc_hyperopt/./ghc_hyperopt/__main__.py", line 6, in <module>
    from vizier import pyglove as pg_vizier
  File "/Users/connorbaker/micromamba/envs/ghc_hyperopt/lib/python3.11/site-packages/vizier/pyglove/__init__.py", line 20, in <module>
    from vizier._src.pyglove.oss_vizier import init
  File "/Users/connorbaker/micromamba/envs/ghc_hyperopt/lib/python3.11/site-packages/vizier/_src/pyglove/oss_vizier.py", line 32, in <module>
    from vizier._src.pyglove import backend
  File "/Users/connorbaker/micromamba/envs/ghc_hyperopt/lib/python3.11/site-packages/vizier/_src/pyglove/backend.py", line 422
    @functools.lru_cache(maxsize=None)d_property
                                      ^^^^^^^^^^
SyntaxError: invalid syntax
```

CC @daiyip -- am I missing something?