### PR TITLE
Resolve datetime deprecation warnings

### DIFF
--- a/vizier/_src/service/vizier_service.py
+++ b/vizier/_src/service/vizier_service.py
@@ -713,7 +713,7 @@ class VizierServicer(vizier_service_pb2_grpc.VizierServiceServicer):
         if (
             output_operation.status
             == vizier_oss_pb2.EarlyStoppingOperation.Status.ACTIVE
-            or datetime.datetime.utcnow()
+            or datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
             - output_operation.completion_time.ToDatetime()
             < self._early_stop_recycle_period
         ):


### PR DESCRIPTION
# PR Summary
This PR fixes the `DeprecationWarning` that appears in Python 3.12+ when using `datetime.utcnow()`. It replaces it with a more future-proof approach: `datetime.now(timezone.utc).replace(tzinfo=None)`. This keeps the `datetime` object naive (without timezone info), which is important for parts of the code that expect it that way, but avoids the warning by using a timezone-aware method first:
```python
# Before (deprecated)  
from datetime import datetime  
naive_time = datetime.utcnow()  # Raises warning  

# Common Fix (timezone-aware)  
from datetime import datetime, timezone  
aware_time = datetime.now(timezone.utc)  # Breaks naive-dependent code  

# This PR's Fix (naive but compliant)  
from datetime import datetime, timezone  
compliant_time = datetime.now(timezone.utc).replace(tzinfo=None)  # No warning, backward-compatible  
```
You can see this warning in the [latest CI run](https://github.com/google/vizier/actions/runs/14478866775/job/40611100710#step:7:197):
```
  /home/runner/work/vizier/vizier/vizier/_src/service/vizier_service.py:716: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    or datetime.datetime.utcnow()
```